### PR TITLE
feat(mobile): implement responsive burger menu, container padding alignment, and terminal text wrapping

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -197,7 +197,11 @@ header {
 .lang-btn {
   background-color: var(--clr-canvas);
   border: var(--border);
-  padding: var(--space-xs) 0.75rem;
+  padding: 0 var(--space-sm);
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: var(--font-main);
   font-weight: var(--weight-bold);
   font-size: 0.9rem;
@@ -215,6 +219,62 @@ header {
 .lang-btn:active {
   transform: translate(1px, 1px);
   box-shadow: 1px 1px 0px var(--clr-ink);
+}
+
+/* Navigation Controls Group */
+.nav-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+/* Burger Button */
+.burger-btn {
+  display: none; /* Hidden on desktop */
+  background-color: var(--clr-canvas);
+  border: var(--border);
+  width: 42px;
+  height: 42px;
+  cursor: pointer;
+  box-shadow: 3px 3px 0px var(--clr-ink);
+  transition: all 0.1s ease;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+}
+
+.burger-btn:hover {
+  background-color: var(--clr-muted);
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0px var(--clr-ink);
+}
+
+.burger-btn:active {
+  transform: translate(1px, 1px);
+  box-shadow: 1px 1px 0px var(--clr-ink);
+}
+
+.burger-bar {
+  display: block;
+  width: 18px;
+  height: 3px;
+  background-color: var(--clr-ink);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+/* Burger Animate to X on Open */
+.burger-btn.open .burger-bar:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.burger-btn.open .burger-bar:nth-child(2) {
+  opacity: 0;
+}
+
+.burger-btn.open .burger-bar:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
 }
 
 section {
@@ -449,36 +509,53 @@ article.project-detail {
 
 @media (max-width: 991px) {
   .nav-bar {
-    position: relative;
-    flex-direction: column;
-    align-items: flex-start;
-    height: auto;
-    padding: var(--space-sm) 0;
-    gap: var(--space-xs);
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    height: 70px;
   }
   
   .nav-logo {
-    font-size: 1.3rem;
+    font-size: 1.4rem;
     padding: var(--space-xs) 0;
   }
 
+  .burger-btn {
+    display: flex;
+  }
+
   .nav-menu {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    gap: 0.25rem 0.4rem;
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: calc(100% + 5px); /* just below the border of the header */
+    right: var(--space-md);
+    background-color: var(--clr-canvas);
+    border: var(--border);
+    box-shadow: var(--shadow);
+    min-width: 220px;
+    z-index: 1000;
+    padding: var(--space-sm);
+    gap: var(--space-xs);
+  }
+
+  .nav-menu.open {
+    display: flex;
+  }
+
+  .nav-menu li {
     width: 100%;
-    padding-right: 60px;
   }
 
   .nav-menu li:last-child {
-    position: absolute;
-    top: 15px;
-    right: 0;
+    position: static;
   }
 
   .nav-link {
-    font-size: 0.8rem;
-    padding: 0.2rem 0.4rem;
+    display: block;
+    font-size: 1rem;
+    padding: var(--space-xs) var(--space-sm);
+    text-align: center;
   }
 
   .overview-grid {

--- a/css/global.css
+++ b/css/global.css
@@ -352,7 +352,7 @@ footer {
 article.project-detail {
   max-width: var(--max-width);
   margin: var(--space-xl) auto;
-  padding: 0 var(--space-md);
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);

--- a/css/index.css
+++ b/css/index.css
@@ -93,7 +93,7 @@
   overflow: hidden;
 }
 
-.terminal-pane {
+.terminal-code {
   background-color: var(--clr-ink);
   color: var(--clr-canvas);
   font-family: 'Courier New', Courier, monospace;
@@ -102,6 +102,7 @@
   flex: 1.2;
   overflow-y: auto;
   white-space: pre-wrap;
+  word-break: break-all;
   position: relative;
 }
 

--- a/index.html
+++ b/index.html
@@ -22,8 +22,16 @@
           <li><a href="#what-i-use" class="nav-link" id="nav-link-what-i-use" data-i18n="nav-what-i-use">What I Use</a></li>
           <li><a href="#experience-education" class="nav-link" id="nav-link-experience" data-i18n="nav-experience">Experience</a></li>
           <li><a href="#contact-cta" class="nav-link" id="nav-link-contact" data-i18n="nav-contact">Contact</a></li>
-          <li><button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button></li>
         </ul>
+        <div class="nav-controls">
+          <button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button>
+          <button class="burger-btn" id="burger-toggle" aria-expanded="false">
+            <span class="sr-only" data-i18n="nav-menu-label">Menu</span>
+            <span class="burger-bar"></span>
+            <span class="burger-bar"></span>
+            <span class="burger-bar"></span>
+          </button>
+        </div>
       </nav>
     </div>
   </header>

--- a/js/main.js
+++ b/js/main.js
@@ -57,6 +57,50 @@ function highlightNav() {
   }
 }
 
+function setupMobileMenu() {
+  const burgerToggle = document.getElementById('burger-toggle');
+  const navMenu = document.getElementById('nav-menu');
+  if (!burgerToggle || !navMenu) {
+    return;
+  }
+
+  function toggleMenu(event) {
+    if (event) {
+      event.stopPropagation();
+    }
+    const isOpen = navMenu.classList.toggle('open');
+    burgerToggle.classList.toggle('open', isOpen);
+    burgerToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+
+  function closeMenu() {
+    navMenu.classList.remove('open');
+    burgerToggle.classList.remove('open');
+    burgerToggle.setAttribute('aria-expanded', 'false');
+  }
+
+  burgerToggle.addEventListener('click', toggleMenu);
+
+  const navLinks = navMenu.querySelectorAll('.nav-link');
+  for (let i = 0; i < navLinks.length; i++) {
+    navLinks[i].addEventListener('click', closeMenu);
+  }
+
+  document.addEventListener('click', function (event) {
+    const isClickInside = burgerToggle.contains(event.target) || navMenu.contains(event.target);
+    if (!isClickInside && navMenu.classList.contains('open')) {
+      closeMenu();
+    }
+  });
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape' && navMenu.classList.contains('open')) {
+      closeMenu();
+      burgerToggle.focus();
+    }
+  });
+}
+
 function init() {
   const savedLang = localStorage.getItem('lang');
   const browserLang = navigator.language || navigator.userLanguage;
@@ -69,6 +113,7 @@ function init() {
     langToggle.addEventListener('click', toggleLanguage);
   }
 
+  setupMobileMenu();
   startTerminalSimulation();
   highlightNav();
 }

--- a/js/translations/global.js
+++ b/js/translations/global.js
@@ -1,5 +1,6 @@
 export const globalTranslations = {
   en: {
+    "nav-menu-label": "Menu",
     "nav-logo": "JuanAcosta",
     "nav-projects": "Projects",
     "nav-how-i-work": "How I Work",
@@ -33,6 +34,7 @@ export const globalTranslations = {
     "table_header_what_tested": "What I Tested"
   },
   fr: {
+    "nav-menu-label": "Menu",
     "nav-logo": "JuanAcosta",
     "nav-projects": "Projets",
     "nav-how-i-work": "Méthode",

--- a/pages/ceramic-shop-django.html
+++ b/pages/ceramic-shop-django.html
@@ -16,10 +16,10 @@
     <div class="container">
       <nav class="nav-bar" id="navbar">
         <a href="../index.html" class="nav-logo" id="nav-logo" data-i18n="nav-logo">JuanAcosta</a>
-        <ul class="nav-menu" id="nav-menu">
-          <li><a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a></li>
-          <li><button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button></li>
-        </ul>
+        <div class="nav-controls">
+          <a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a>
+          <button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button>
+        </div>
       </nav>
     </div>
   </header>

--- a/pages/custom-keyboard-collective.html
+++ b/pages/custom-keyboard-collective.html
@@ -16,10 +16,10 @@
     <div class="container">
       <nav class="nav-bar" id="navbar">
         <a href="../index.html" class="nav-logo" id="nav-logo" data-i18n="nav-logo">JuanAcosta</a>
-        <ul class="nav-menu" id="nav-menu">
-          <li><a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a></li>
-          <li><button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button></li>
-        </ul>
+        <div class="nav-controls">
+          <a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a>
+          <button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button>
+        </div>
       </nav>
     </div>
   </header>

--- a/pages/pozole-flask-api.html
+++ b/pages/pozole-flask-api.html
@@ -16,10 +16,10 @@
     <div class="container">
       <nav class="nav-bar" id="navbar">
         <a href="../index.html" class="nav-logo" id="nav-logo" data-i18n="nav-logo">JuanAcosta</a>
-        <ul class="nav-menu" id="nav-menu">
-          <li><a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a></li>
-          <li><button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button></li>
-        </ul>
+        <div class="nav-controls">
+          <a href="../index.html" class="nav-link" id="nav-link-home" data-i18n="back-to-home">← Back to Home</a>
+          <button class="lang-btn" id="lang-toggle" aria-label="Switch to French">FR</button>
+        </div>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
# Overview

This PR improves mobile usability, layout consistency, and accessibility across the portfolio site. It replaces the previous multi-row mobile navigation bar with a premium Neo-brutalist burger menu and popup list, corrects sub-page alignment padding issues, and fixes text wrapping in the mock IDE typing animation.

---

## Key Changes

###  **1. Mobile Burger Menu & Popup Navigation (`index.html`, `global.css`, `main.js`)**
- **Restructured Header Markup**: Pulled the language toggle out of the navigation list and grouped it inside a `.nav-controls` block alongside the new burger toggle button.
- **Neo-Brutalist Square Toggle**: Designed a square burger button (`42px` by `42px`) that aligns perfectly in size with the language switcher button. It has a high-contrast thick border, offset flat shadow, and physical translation transitions on hover/active states.
- **Burger Animations**: Added horizontal CSS bar transitions that animate into an "X" shape when open and fade out the middle bar.
- **Absolute Popup Menu**: Updated the `max-width: 991px` media query to position the mobile links list as a padded, absolute Neo-brutalist card container. Menu links translate and draw custom shadows on hover/tap.
- **Event-Driven UX**: Added JavaScript functions (`main.js`) to toggle the `.open` state and `aria-expanded` attributes. Closes automatically if a user clicks a nav link, clicks outside the menu popup, or presses the `Escape` key.

### **2. Subpage Header Alignment (`pages/*.html`)**
- Removed the burger menu toggle from the project details sub-pages because they only contain a single navigation link ("← Back to Home").
- Placed the "← Back to Home" link and language toggle directly side-by-side inside `.nav-controls` on the right to maintain a clean, single-row layout on mobile without wrapping.

### **3. Page Container Alignment (`global.css`)**
- Removed redundant `padding: 0 var(--space-md)` from `article.project-detail`. Since this block is already wrapped inside a `.container` (which provides horizontal safety padding), the nested padding caused a double-padding layout mismatch.
- Project cards now align perfectly with the header boundary on all viewports, matching the homepage's alignment structure.

### **4. Playwright Mock Terminal Text Wrapping (`index.css`)**
- Fixed a class mismatch typo where the mock terminal was styled with `.terminal-pane` in CSS but marked as `.terminal-code` in HTML and JS. Resolving this applies the dark background, light text, and monospace font as originally designed.
- Added `word-break: break-all` and `white-space: pre-wrap` so that longer mock commands (like `pytest tests/e2e/test_portfolio.py`) wrap cleanly onto a new line on narrower mobile viewports.

### **5. Translations (`global.js`)**
- Added the `"nav-menu-label"` English and French strings to translate the screen-reader accessibility helper tag in the burger button.

### **PR Status & Quality Checks**
- [x] Tested and verified on responsive mobile layouts down to 360px width.
- [x] Biome linter and formatter executed on all modified JavaScript assets.
- [x] Accessibility elements (`aria-expanded`, focus targets, screen-reader helper spans) checked.
